### PR TITLE
Merge updates directly so automerge works, and enable config migration

### DIFF
--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -19,8 +19,5 @@ jobs:
         with:
           node-version: "24"
 
-      - name: Install devDependencies
-        run: npm ci --only=dev
-
-      - name: validate renovate.json
-        run: npm run validate-config
+      - name: Validate default.json
+        run: npx --yes --package renovate -- renovate-config-validator default.json

--- a/default.json
+++ b/default.json
@@ -1,9 +1,12 @@
 {
     "$schema": "https://docs.renovatebot.com/renovate-schema.json",
     "extends": [
-        "config:recommended"
+        "config:recommended",
+        ":configMigration",
+        ":semanticCommitTypeAll(chore)"
     ],
     "timezone": "Asia/Tokyo",
+    "platformAutomerge": false,
     "schedule": [
         "after 1am and before 3am on monday"
     ],


### PR DESCRIPTION
## What

Add to the shared preset `default.json`:

- `platformAutomerge: false`
- `:configMigration` and `:semanticCommitTypeAll(chore)` in `extends`

## Why

The preset declared `automerge: true` for minor/patch/pin but nothing ever auto-merged and PRs piled up. Cause: Renovate's `platformAutomerge` defaults to true, which requires GitHub's repo-level "Allow auto-merge" — unavailable on these private free-plan repos (no branch protection / required checks either).

- `platformAutomerge: false` makes Renovate merge directly via the API, independent of repo settings; it waits for CI to pass first (`ignoreTests` defaults to false), so it is gated by CI even without required checks.
- `:configMigration` auto-migrates deprecated options (e.g. the preset's deprecated `excludePackagePrefixes`).
- `:semanticCommitTypeAll(chore)` standardizes commit prefixes to `chore(deps)`.

## Note

Also fixes the validator CI (was `npm ci` in a pnpm repo) to run via npx.