### PR TITLE
Replace pnpm allowBuilds placeholders with real booleans

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,8 +1,8 @@
 allowBuilds:
-  core-js-pure: set this to true or false
-  dtrace-provider: set this to true or false
-  protobufjs: set this to true or false
-  re2: set this to true or false
+  core-js-pure: false
+  dtrace-provider: false
+  protobufjs: false
+  re2: false
 overrides:
   protobufjs: 8.3.0
   simple-git: 3.36.0


### PR DESCRIPTION
## What
Replace the literal `set this to true or false` placeholder strings in `pnpm-workspace.yaml` `allowBuilds` with `false` for all four packages (core-js-pure, dtrace-provider, protobufjs, re2).

## Why
pnpm 11 treats unapproved build scripts as a hard error (`ERR_PNPM_IGNORED_BUILDS`), and the placeholder strings do not count as a decision, so `pnpm install` exits 1 on a clean checkout. This is also the likely cause of the `renovate/artifacts` failure blocking #30 — Renovate cannot regenerate the lockfile when install fails. None of the four packages need build scripts for `renovate-config-validator`, verified locally with `pnpm install --frozen-lockfile` + `pnpm run validate-config` both passing.

## Related
ref. #30