### PR TITLE
Drop sha512 hash from packageManager to fix persistent renovate/artifacts failure

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,5 +5,5 @@
   "devDependencies": {
     "renovate": "^43.150.0"
   },
-  "packageManager": "pnpm@11.1.2+sha512.415a1cc25974731e75455c1468371be74c5aa5fb7621b50d4056d222451609f11412f23fd602e6169f1e060466641f798597e1be961a10688836a67b16569499"
+  "packageManager": "pnpm@11.1.2"
 }


### PR DESCRIPTION
## What

Remove the `+sha512.<hash>` suffix from the `packageManager` field in `package.json`, leaving `pnpm@11.1.2`.

## Why

PR #30 (and any pnpm update PR) has shown a persistent `renovate/artifacts: FAILURE` commit status. Root cause: when the `packageManager` field contains a sha512 hash, Renovate recomputes the hash on a version bump by running `corepack use pnpm@<version>`. That command triggers an uncontrolled full install in Renovate's artifact sandbox and fails there, producing `Command failed: corepack use pnpm@<version>` and the artifact-update failure status. As a side effect Renovate commits the bump with the hash stripped (the data-loss symptom), so the committed lockfile is internally consistent yet the FAILURE status remains.

This is a known upstream Renovate limitation (renovatebot/renovate #37772, discussion #36904). The recommended workaround is to remove the sha512 hash so Renovate performs a plain version-string update with a normal lockfile refresh and never invokes `corepack use`. Verified locally: `pnpm install --lockfile-only` with the de-hashed field leaves the lockfile unchanged.

The validate workflow only runs on `default.json` changes, so this package.json-only change has no required checks.