### PR TITLE
Set rebaseWhen to auto to fix frozen automerge on grouped PRs

### DIFF
--- a/default.json
+++ b/default.json
@@ -9,7 +9,7 @@
     ],
     "timezone": "Asia/Tokyo",
     "platformAutomerge": false,
-    "rebaseWhen": "conflicted",
+    "rebaseWhen": "auto",
     "schedule": [
         "after 1am and before 3am on monday"
     ],


### PR DESCRIPTION
## What

Change `rebaseWhen` in `default.json` from `"conflicted"` to `"auto"`. No other preset values are touched.

## Why

Cross-repo diagnosis (roulette PR #172, word-counter #127, next-ssg-template #70) found the same org-wide failure mode: a grouped non-major update PR (e.g. `group:allNonMajor`) that never develops a merge conflict is never force-pushed by Renovate, so newly released versions keep piling up on top of an increasingly stale branch. Because the branch is never refreshed, the `renovate/stability-days` status stays stuck in `pending` indefinitely even though CI is green, and `automerge` never fires — roulette #172 sat frozen from 2026-06-21 to 2026-07-11 this way.

`rebaseWhen: "conflicted"` only rebases a branch when it has a literal git conflict with the base branch; it does not rebase just because the branch fell behind or new releases showed up. Per the [Renovate rebaseWhen docs](https://docs.renovatebot.com/configuration-options/#rebasewhen), when `automerge` is enabled the recommended and default-equivalent value is `"auto"`, which behaves like `"behind-base-branch"`: Renovate keeps the branch current and re-evaluates `minimumReleaseAge`/stability-days on every update, so grouped PRs stop freezing. The CI-churn savings that motivated `"conflicted"` are not worth automerge silently failing to fire.

Validated locally with `renovate-config-validator default.json` (see CI run on this PR, which also exercises the same validator via the "Renovate Config Validator" workflow since this PR touches `default.json`).