### PR TITLE
Pin workflow actions by SHA

### DIFF
--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -12,10 +12,10 @@ jobs:
 
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: "24"
 


### PR DESCRIPTION
## What

Pin the action refs in `.github/workflows/validate.yaml` to full commit SHAs (with version comments) instead of floating tags:

- `actions/checkout@v6` -> `actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3`
- `actions/setup-node@v6` -> `actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0`

## Why

House convention is that every workflow action is pinned to an immutable commit SHA (with a `# vX.Y.Z` comment maintained by Renovate) for supply-chain safety and reproducibility. This is pin hygiene only: both actions were already resolving to node24 runtimes at their current tags, so there is no runtime behavior change.