### PR TITLE
Exclude broken pnpm 11.12.0 release from updates

### DIFF
--- a/default.json
+++ b/default.json
@@ -77,6 +77,13 @@
                 "!actions/{/,}**"
             ],
             "pinDigests": true
+        },
+        {
+            "description": "pnpm 11.12.0 is a broken release: its tarball fails to install, so any self-switch to it crashes (pnpm/pnpm#12955, pnpm/action-setup#276). Remove once a fixed release ships.",
+            "matchPackageNames": [
+                "pnpm"
+            ],
+            "allowedVersions": "!/^11\\.12\\.0$/"
         }
     ]
 }


### PR DESCRIPTION
## What

Add a `packageRules` entry that excludes `pnpm@11.12.0` via `allowedVersions` (`!/^11\.12\.0$/`).

## Why

pnpm 11.12.0 is a broken release: the published tarball fails to install, so any pnpm self-switch to it crashes with `Cannot use 'in' operator to search for 'integrity' in undefined`. This currently turns CI red on every Renovate PR that bumps pnpm to 11.12.0 (reproduced locally: switching from both 11.7.0 and 11.11.0 to 11.12.0 fails deterministically; 11.11.0 works).

Upstream reports:
- pnpm/pnpm#12955 (11.12.0 release fails to install from tarball)
- pnpm/action-setup#276 (identical error in CI)

The rule only skips this single version — once a fixed release (e.g. 11.12.1) ships, Renovate picks it up normally. Remove the rule after upstream confirms the fix if desired.
