### PR TITLE
Fix adm-zip high-severity Dependabot alert

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,6 +5,7 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
+  adm-zip: 0.6.0
   protobufjs: 8.3.0
   simple-git: 3.36.0
   js-yaml@3: 3.15.0
@@ -801,9 +802,9 @@ packages:
     engines: {node: '>=0.4.0'}
     hasBin: true
 
-  adm-zip@0.5.17:
-    resolution: {integrity: sha512-+Ut8d9LLqwEvHHJl1+PIHqoyDxFgVN847JTVM3Izi3xHDWPE4UtzzXysMZQs64DMcrJfBeS/uoEP4AD3HQHnQQ==}
-    engines: {node: '>=12.0'}
+  adm-zip@0.6.0:
+    resolution: {integrity: sha512-XleryMhbuksdKtofnWZ9Sk+4CUTbms4Mb/EU32SZwToAyZ5RgVos/ki8n+yr0LWHOGKuakbXTuuYNHLQjhddgg==}
+    engines: {node: '>=14.0'}
 
   ae-cvss-calculator@1.0.12:
     resolution: {integrity: sha512-YVO+dhb8sZubNeL9pqSlN5hyZGC8hkAwnThnd3EimUGZtJEMeuy4kMb7zMCAsBiMr/RxklH0oY7DCsFV/B7peg==}
@@ -3428,7 +3429,7 @@ snapshots:
   '@renovatebot/osv-offline@2.5.0':
     dependencies:
       '@renovatebot/osv-offline-db': 2.5.0
-      adm-zip: 0.5.17
+      adm-zip: 0.6.0
       debug: 4.4.3
       fs-extra: 11.3.4
       got: 14.6.6
@@ -3816,7 +3817,7 @@ snapshots:
 
   acorn@8.16.0: {}
 
-  adm-zip@0.5.17: {}
+  adm-zip@0.6.0: {}
 
   ae-cvss-calculator@1.0.12: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -4,6 +4,7 @@ allowBuilds:
   protobufjs: false
   re2: false
 overrides:
+  adm-zip: 0.6.0
   protobufjs: 8.3.0
   simple-git: 3.36.0
   js-yaml@3: 3.15.0


### PR DESCRIPTION
## What

Pin the transitive `adm-zip` dependency to `0.6.0` via a `pnpm` override (`pnpm-workspace.yaml`) and regenerate `pnpm-lock.yaml`.

## Why

Dependabot high-severity alert GHSA-xcpc-8h2w-3j85: a crafted ZIP can cause `adm-zip` to allocate ~4GB of memory. Vulnerable range is `< 0.6.0`; the fix landed in `0.6.0`.

adm-zip is pulled in transitively through `renovate` → `@renovatebot/osv-offline@2.5.0`, whose declared range (`~0.5.17`) will not resolve to `0.6.0` on its own, so an `overrides` entry is the least-invasive correct fix and matches the existing override pattern in this repo. `pnpm why adm-zip` confirms a single resolved copy at `0.6.0`, and `renovate-config-validator` passes.