### PR TITLE
Use strict internalChecksFilter so grouped non-major PRs converge

### DIFF
--- a/default.json
+++ b/default.json
@@ -16,7 +16,7 @@
     "prHourlyLimit": 0,
     "updateNotScheduled": false,
     "dependencyDashboard": true,
-    "internalChecksFilter": "none",
+    "internalChecksFilter": "strict",
     "packageRules": [
         {
             "matchPackageNames": [


### PR DESCRIPTION
## What

Change `internalChecksFilter` in `default.json` from `"none"` to `"strict"` (one line; nothing else in the preset changes).

`"strict"` is also Renovate's own default, but this preset states its choices explicitly, so the value is spelled out rather than deleted.

## Why

The combination of `group:allNonMajor` + `minimumReleaseAge: "14 days"` + `internalChecksFilter: "none"` + weekly rebase means grouped non-major PRs can never converge to automerge.

With `"none"`, Renovate always selects the absolute newest release, regardless of release age. Every time any package in the group publishes a new version, the rebase pulls that version in and the 14-day stability clock restarts, so `renovate/stability-days` stays pending and `automerge` never fires. Fast-releasing packages (`next`, `pnpm`) can loop indefinitely and the queue stalls silently.

Three resets observed on 2026-08-08/09 across repos consuming this preset:

| Repo / PR | Package that reset the clock | Age at rebase | New unblock date |
|---|---|---|---|
| `word-counter` #149 | pnpm 11.18.0 | 11 days | — |
| `renovate-config` #30 | protobufjs 8.7.2 | 3.5 hours | 2026-08-22 |
| `roulette` #191 | next 16.2.12 -> 16.3.0 retarget on rebase | — | 2026-08-17 |

With `"strict"`, Renovate instead selects the newest release that already satisfies `minimumReleaseAge`, so the 14-day soak is fully preserved while PRs stop chasing HEAD. If every candidate version for a dependency is still soaking, that dependency is held back from the group rather than blocking it, so the rest of the group can still automerge.

The upstream docs recommend this pairing directly:

> The `flexible` mode can result in "flapping" of Pull Requests [...] We recommend that you use the `strict` mode, and enable the `dependencyDashboard` so that you can see suppressed PRs.

This preset already sets `dependencyDashboard: true`, so held-back updates stay visible. Renovate's own `security:minimumReleaseAgeNpm` preset likewise pairs `minimumReleaseAge` with `internalChecksFilter: "strict"`.

## Checked for regressions

- **Major flow unchanged.** `internalChecksFilter` only affects which version is selected for an update; `dependencyDashboardApproval: true` on `matchUpdateTypes: ["major"]` still gates majors behind dashboard approval.
- **Security PRs are not delayed.** Renovate's `vulnerabilityAlerts` defaults include `minimumReleaseAge: null` (plus `groupName: null`, `schedule: []`, `prCreation: "immediate"`), and that config is merged *last*, after `packageRules`. Vulnerability remediations therefore bypass the 14-day soak entirely and are unaffected by this setting, so no vulnerability carve-out is needed. This matches observed behaviour in this repo: the `[security]` PRs #38, #39, #40 and #42 were all raised ungrouped and merged within days.

## Verification

```
$ renovate-config-validator default.json
 INFO: Validating default.json as global config
 INFO: Config validated successfully
```
