### PR TITLE
Override vulnerable transitive dependencies brace-expansion and re2

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -13,6 +13,9 @@ overrides:
   undici: 6.28.0
   tar: 7.5.18
   markdown-it: 14.2.0
+  brace-expansion@1: 1.1.16
+  brace-expansion@5: 5.0.7
+  re2: 1.26.1
 
 importers:
 
@@ -788,9 +791,9 @@ packages:
     engines: {node: '>=18.12.0'}
     hasBin: true
 
-  abbrev@4.0.0:
-    resolution: {integrity: sha512-a1wflyaL0tHtJSmLSOVybYhy22vRih4eduhhrkcjgrWGnRfrZtovJ2FRjxuTtkkj47O/baf0R86QU5OuYpz8fA==}
-    engines: {node: ^20.17.0 || >=22.9.0}
+  abbrev@5.0.0:
+    resolution: {integrity: sha512-/XrFJgzQQQHpti1raDJC6m4ws6aNktmjBlhk8Fdlk7LwCEuDoieEJJY9OFHjfiFJFFRM2tK+Ky/IsfbbmlMu1w==}
+    engines: {node: ^22.22.2 || ^24.15.0 || >=26.0.0}
 
   acorn-import-attributes@1.9.5:
     resolution: {integrity: sha512-n02Vykv5uA3eHGM/Z2dQrcD56kL8TyDb2p1+0P83PClMnC/nc+anbQRhIOWnSq4Ke/KvDPrY3C9hDtC/A3eHnQ==}
@@ -880,11 +883,11 @@ packages:
   bowser@2.14.1:
     resolution: {integrity: sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg==}
 
-  brace-expansion@1.1.14:
-    resolution: {integrity: sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==}
+  brace-expansion@1.1.16:
+    resolution: {integrity: sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==}
 
-  brace-expansion@5.0.6:
-    resolution: {integrity: sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==}
+  brace-expansion@5.0.7:
+    resolution: {integrity: sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==}
     engines: {node: 18 || 20 || >=22}
 
   braces@3.0.3:
@@ -1464,8 +1467,8 @@ packages:
     resolution: {integrity: sha512-IBTdIkzZNOpqm7q3dRqJvMaldXjDHWkEDfrwGEQTs5eaQMWV+djAhR+wahyNNMAa+qpbDUhBMVt4ZKNwpPm7xQ==}
     engines: {node: ^20.17.0 || >=22.9.0}
 
-  install-artifact-from-github@1.6.0:
-    resolution: {integrity: sha512-wKsuzN8fy8QK7iEUqyWTQmvZ1QFGPn1xyl3/1iIIDthDjS7Hn9HoPwHlNakZirWbCsbad0lZMkr6Xfbpe1pUzw==}
+  install-artifact-from-github@1.7.0:
+    resolution: {integrity: sha512-qAb91yAKVF9rFY4rVP21ZtYUyCScxAFt9udwzVWNLBE1pQcdQeB2gd1HlNPcQNYCzCDvJ/QJQPuWQ6aTmSlU8g==}
     engines: {node: '>=18'}
     hasBin: true
 
@@ -1840,6 +1843,9 @@ packages:
   nan@2.27.0:
     resolution: {integrity: sha512-hC+0LidcL3XE4rp1C4H54KujgXKzbfyTngZTwBByQxsOxCEKZT0MPQ4hOKUH2jU1OYstqdDH4onyHPDzcV0XdQ==}
 
+  nan@2.28.0:
+    resolution: {integrity: sha512-fTsDz99OTq2sVePhGdp4qQhggZFtKr64ZNVyVajRKtMOkJxYekplBh577PiJB12v/D3s2E5cGtOI45LWp6rnLQ==}
+
   napi-build-utils@2.0.0:
     resolution: {integrity: sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA==}
 
@@ -1867,17 +1873,17 @@ packages:
     resolution: {integrity: sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
-  node-gyp@12.3.0:
-    resolution: {integrity: sha512-QNcUWM+HgJplcPzBvFBZ9VXacyGZ4+VTOb80PwWR+TlVzoHbRKULNEzpRsnaoxG3Wzr7Qh7BYxGDU3CbKib2Yg==}
-    engines: {node: ^20.17.0 || >=22.9.0}
+  node-gyp@13.0.1:
+    resolution: {integrity: sha512-piOr0S10qy5THB+q5BdqkoOx65XL/tjTMUAit3vciPNp+snTOBnGunWH1Rz7XZUxf2T9uFrfT/Ty4+aC3yPeyg==}
+    engines: {node: ^22.22.2 || ^24.15.0 || >=26.0.0}
     hasBin: true
 
   node-html-parser@7.1.0:
     resolution: {integrity: sha512-iJo8b2uYGT40Y8BTyy5ufL6IVbN8rbm/1QK2xffXU/1a/v3AAa0d1YAoqBNYqaS4R/HajkWIpIfdE6KcyFh1AQ==}
 
-  nopt@9.0.0:
-    resolution: {integrity: sha512-Zhq3a+yFKrYwSBluL4H9XP3m3y5uvQkB/09CwDruCiRmR/UJYnn9W4R48ry0uGC70aeTPKLynBtscP9efFFcPw==}
-    engines: {node: ^20.17.0 || >=22.9.0}
+  nopt@10.0.1:
+    resolution: {integrity: sha512-df3sBr/6ax9hSGuC3CspvLlbnX8cP5L5nZwXF8cGN8l0zSWR6BvzmQ6jPUKjvo6+/xdpkNvEcucBNUdBeeV13g==}
+    engines: {node: ^22.22.2 || ^24.15.0 || >=26.0.0}
     hasBin: true
 
   normalize-url@6.1.0:
@@ -2029,9 +2035,9 @@ packages:
     engines: {node: '>=14'}
     hasBin: true
 
-  proc-log@6.1.0:
-    resolution: {integrity: sha512-iG+GYldRf2BQ0UDUAd6JQ/RwzaQy6mXmsk/IzlYyal4A4SNFw54MeH4/tLkF4I5WoWG9SQwuqWzS99jaFQHBuQ==}
-    engines: {node: ^20.17.0 || >=22.9.0}
+  proc-log@7.0.0:
+    resolution: {integrity: sha512-FYgfaA69XZ93zaXLoMNQ+ViDXGGBgR8aLh03txzcFhV+9xOXx7+8DLCULrKKpR9+GsH9ZfHm82aSUPpozX0Ztg==}
+    engines: {node: ^22.22.2 || ^24.15.0 || >=26.0.0}
 
   protobufjs@8.6.5:
     resolution: {integrity: sha512-zeE5LPpencAGXvsxyOYmEgJhxzHY8IsmPAFzstZVhDSVT8QH03q6gMZwZRaQGApevZbAL6u28ugs4CC+YKB2jQ==}
@@ -2066,8 +2072,9 @@ packages:
     resolution: {integrity: sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==}
     hasBin: true
 
-  re2@1.24.0:
-    resolution: {integrity: sha512-pBm6cMaOb0Yb0kg0Sfw/k4LwDMkPScb/NVd7GrEllDwfsPZstsZIo93A6Nn0wZuWJw3h57GdzkrOk81EofKY/g==}
+  re2@1.26.1:
+    resolution: {integrity: sha512-oi79a4h6EO3PAwNsDMWgeCcsRGQEUa52DIgOiFTZGDEZocEXG9h+oXy0qZqndo47huUeJuVWSoOJIEhOupqOcg==}
+    engines: {node: ^22.22.2 || ^24.15.0 || >=26.0.0}
 
   read-yaml-file@2.1.0:
     resolution: {integrity: sha512-UkRNRIwnhG+y7hpqnycCL/xbTk7+ia9VuVTC0S+zVbwd65DI9eUpRMfsWIGrCWxTU/mi+JW8cHQCrv+zfCbEPQ==}
@@ -2408,9 +2415,9 @@ packages:
     engines: {node: '>= 8'}
     hasBin: true
 
-  which@6.0.1:
-    resolution: {integrity: sha512-oGLe46MIrCRqX7ytPUf66EAYvdeMIZYn3WaocqqKZAxrBpkqHfL/qvTyJ/bTk5+AqHCjXmrv3CEWgy368zhRUg==}
-    engines: {node: ^20.17.0 || >=22.9.0}
+  which@7.0.0:
+    resolution: {integrity: sha512-RancgH2dmbLdHl6LRhEqvklWMgl/Hdnun0Y90KhBOLkMefg8Qa7/Zel8Sm+8HEcP6DEjzsWzpkuBQEZok58isA==}
+    engines: {node: ^22.22.2 || ^24.15.0 || >=26.0.0}
     hasBin: true
 
   wordwrap@1.0.0:
@@ -3808,7 +3815,7 @@ snapshots:
     transitivePeerDependencies:
       - typanion
 
-  abbrev@4.0.0:
+  abbrev@5.0.0:
     optional: true
 
   acorn-import-attributes@1.9.5(acorn@8.16.0):
@@ -3887,13 +3894,13 @@ snapshots:
 
   bowser@2.14.1: {}
 
-  brace-expansion@1.1.14:
+  brace-expansion@1.1.16:
     dependencies:
       balanced-match: 1.0.2
       concat-map: 0.0.1
     optional: true
 
-  brace-expansion@5.0.6:
+  brace-expansion@5.0.7:
     dependencies:
       balanced-match: 4.0.4
 
@@ -4524,7 +4531,7 @@ snapshots:
 
   ini@6.0.0: {}
 
-  install-artifact-from-github@1.6.0:
+  install-artifact-from-github@1.7.0:
     optional: true
 
   is-arrayish@0.2.1: {}
@@ -4979,11 +4986,11 @@ snapshots:
 
   minimatch@10.2.5:
     dependencies:
-      brace-expansion: 5.0.6
+      brace-expansion: 5.0.7
 
   minimatch@3.1.5:
     dependencies:
-      brace-expansion: 1.1.14
+      brace-expansion: 1.1.16
     optional: true
 
   minimist@1.2.8: {}
@@ -5037,6 +5044,9 @@ snapshots:
   nan@2.27.0:
     optional: true
 
+  nan@2.28.0:
+    optional: true
+
   napi-build-utils@2.0.0:
     optional: true
 
@@ -5060,18 +5070,18 @@ snapshots:
       fetch-blob: 3.2.0
       formdata-polyfill: 4.0.10
 
-  node-gyp@12.3.0:
+  node-gyp@13.0.1:
     dependencies:
       env-paths: 2.2.1
       exponential-backoff: 3.1.3
       graceful-fs: 4.2.11
-      nopt: 9.0.0
-      proc-log: 6.1.0
+      nopt: 10.0.1
+      proc-log: 7.0.0
       semver: 7.7.4
       tar: 7.5.18
       tinyglobby: 0.2.16
       undici: 6.28.0
-      which: 6.0.1
+      which: 7.0.0
     optional: true
 
   node-html-parser@7.1.0:
@@ -5079,9 +5089,9 @@ snapshots:
       css-select: 5.2.2
       he: 1.2.0
 
-  nopt@9.0.0:
+  nopt@10.0.1:
     dependencies:
-      abbrev: 4.0.0
+      abbrev: 5.0.0
     optional: true
 
   normalize-url@6.1.0: {}
@@ -5213,7 +5223,7 @@ snapshots:
 
   prettier@3.8.1: {}
 
-  proc-log@6.1.0:
+  proc-log@7.0.0:
     optional: true
 
   protobufjs@8.6.5:
@@ -5247,11 +5257,11 @@ snapshots:
       strip-json-comments: 2.0.1
     optional: true
 
-  re2@1.24.0:
+  re2@1.26.1:
     dependencies:
-      install-artifact-from-github: 1.6.0
-      nan: 2.27.0
-      node-gyp: 12.3.0
+      install-artifact-from-github: 1.7.0
+      nan: 2.28.0
+      node-gyp: 13.0.1
     optional: true
 
   read-yaml-file@2.1.0:
@@ -5432,7 +5442,7 @@ snapshots:
     optionalDependencies:
       better-sqlite3: 12.9.0
       openpgp: 6.3.0
-      re2: 1.24.0
+      re2: 1.26.1
     transitivePeerDependencies:
       - '@node-rs/xxhash'
       - supports-color
@@ -5761,7 +5771,7 @@ snapshots:
     dependencies:
       isexe: 2.0.0
 
-  which@6.0.1:
+  which@7.0.0:
     dependencies:
       isexe: 4.0.0
     optional: true

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -12,3 +12,6 @@ overrides:
   undici: 6.28.0
   tar: 7.5.18
   markdown-it: 14.2.0
+  brace-expansion@1: 1.1.16
+  brace-expansion@5: 5.0.7
+  re2: 1.26.1


### PR DESCRIPTION
## What

Add three `pnpm-workspace.yaml` overrides pinning vulnerable transitive dependencies to their first patched versions, and regenerate `pnpm-lock.yaml`. This extends the existing security-override pattern already used for `adm-zip`, `protobufjs`, `simple-git`, `js-yaml`, `undici`, `tar` and `markdown-it` (#37-#42).

| GHSA | Severity | Package | Was | Now |
|---|---|---|---|---|
| [GHSA-3jxr-9vmj-r5cp](https://github.com/advisories/GHSA-3jxr-9vmj-r5cp) | High | `brace-expansion` (1.x) | 1.1.14 | 1.1.16 |
| [GHSA-3jxr-9vmj-r5cp](https://github.com/advisories/GHSA-3jxr-9vmj-r5cp) | High | `brace-expansion` (5.x) | 5.0.6 | 5.0.7 |
| [GHSA-j4r3-hg7j-8chg](https://github.com/advisories/GHSA-j4r3-hg7j-8chg) | Medium | `re2` | 1.24.0 | 1.26.1 |
| [GHSA-ff84-5f28-78qj](https://github.com/advisories/GHSA-ff84-5f28-78qj) | Medium | `re2` | 1.24.0 | 1.26.1 |
| [GHSA-8hcv-x26h-mcgp](https://github.com/advisories/GHSA-8hcv-x26h-mcgp) | Medium | `re2` | 1.24.0 | 1.26.1 |

The three `re2` advisories have first patched versions 1.25.1, 1.25.2 and 1.26.1 respectively; 1.26.1 satisfies all three, so a single override covers them.

## Why

These are the five open Dependabot alerts on `main`. All are development scope: every affected package is reachable only through the `renovate` devDependency, which this repo uses solely to run `renovate-config-validator` in CI. Consumers that `extends` this preset are not affected, since they consume `default.json` only.

Renovate cannot fix these on its own: `re2` is declared by `renovate` as an exactly pinned `optionalDependencies` entry (`"re2": "1.24.0"`), and both `brace-expansion` copies are indirect transitive dependencies. An override is the only mechanism available, which is why this repo already uses the pattern.

## Compatibility

Both `brace-expansion` overrides stay within the range their parent declares, so nothing is force-downgraded or force-majored:

- `minimatch@3.1.5` declares `brace-expansion: ^1.1.7` -> 1.1.16 satisfies it
- `minimatch@10.2.5` declares `brace-expansion: ^5.0.5` -> 5.0.7 satisfies it

`re2` 1.24.0 -> 1.26.1 is a minor bump inside the same major and does **not** require a `renovate` major. It does override `renovate`'s exact pin, but the risk is minimal: `re2` is an `optionalDependency` that `renovate` degrades away from when unavailable, and this repo already sets `allowBuilds: re2: false`, so its native addon is never built here in the first place.

`pnpm why` confirms every path:

```
re2@1.24.0 -> renovate@43.150.0 -> the root project (devDependencies)
brace-expansion@1.1.14 -> minimatch@3.1.5 -> glob@6.0.4 -> rimraf@2.4.5 -> mv@2.1.1 -> bunyan@1.8.15 -> renovate@43.150.0
brace-expansion@5.0.6 -> minimatch@10.2.5 -> editorconfig@3.0.2 / glob@13.0.6 / cacache@20.0.4 -> renovate@43.150.0
```

No other versions of either package remain in the lockfile after regeneration.

## Verification

```
$ pnpm install --frozen-lockfile
Lockfile is up to date, resolution step is skipped
Done in 2.1s using pnpm v11.1.2

$ renovate-config-validator default.json
 INFO: Validating default.json as global config
 INFO: Config validated successfully
```

Note: the `Renovate Config Validator` workflow only triggers on changes to `default.json`, which this PR does not touch, so it does not run here. The validator was run locally against the patched dependency tree instead, which is the stronger check for this change.
