### PR TITLE
Bump js-yaml overrides to patched versions for GHSA-5p4m-2wfm-xmqj

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,8 +8,8 @@ overrides:
   adm-zip: 0.6.0
   protobufjs: 8.6.5
   simple-git: 3.36.0
-  js-yaml@3: 3.15.0
-  js-yaml@4: 4.3.0
+  js-yaml@3: 3.15.1
+  js-yaml@4: 4.3.1
   undici: 6.28.0
   tar: 7.5.18
   markdown-it: 14.2.0
@@ -1526,12 +1526,12 @@ packages:
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
-  js-yaml@3.15.0:
-    resolution: {integrity: sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==}
+  js-yaml@3.15.1:
+    resolution: {integrity: sha512-S99WuO3HlhO3XN41EtYUNl9zzXjoJx7QvmipxsJVxtCBT0YHEFy+iOJhjSvrmV12nYhWpZaM8lPHkJm0yUMbag==}
     hasBin: true
 
-  js-yaml@4.3.0:
-    resolution: {integrity: sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==}
+  js-yaml@4.3.1:
+    resolution: {integrity: sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==}
     hasBin: true
 
   json-bigint@1.0.0:
@@ -3799,7 +3799,7 @@ snapshots:
 
   '@yarnpkg/parsers@3.0.3':
     dependencies:
-      js-yaml: 3.15.0
+      js-yaml: 3.15.1
       tslib: 2.8.1
 
   '@yarnpkg/shell@4.1.3(typanion@3.14.0)':
@@ -4569,12 +4569,12 @@ snapshots:
 
   js-tokens@4.0.0: {}
 
-  js-yaml@3.15.0:
+  js-yaml@3.15.1:
     dependencies:
       argparse: 1.0.10
       esprima: 4.0.1
 
-  js-yaml@4.3.0:
+  js-yaml@4.3.1:
     dependencies:
       argparse: 2.0.1
 
@@ -5266,7 +5266,7 @@ snapshots:
 
   read-yaml-file@2.1.0:
     dependencies:
-      js-yaml: 4.3.0
+      js-yaml: 4.3.1
       strip-bom: 4.0.0
 
   readable-stream@3.6.2:
@@ -5794,7 +5794,7 @@ snapshots:
 
   write-yaml-file@4.2.0:
     dependencies:
-      js-yaml: 4.3.0
+      js-yaml: 4.3.1
       write-file-atomic: 3.0.3
 
   xml-naming@0.1.0: {}

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -7,8 +7,8 @@ overrides:
   adm-zip: 0.6.0
   protobufjs: 8.6.5
   simple-git: 3.36.0
-  js-yaml@3: 3.15.0
-  js-yaml@4: 4.3.0
+  js-yaml@3: 3.15.1
+  js-yaml@4: 4.3.1
   undici: 6.28.0
   tar: 7.5.18
   markdown-it: 14.2.0


### PR DESCRIPTION
## What

Bump the existing `js-yaml` overrides in `pnpm-workspace.yaml` to the patched versions and regenerate `pnpm-lock.yaml`.

| GHSA | Severity | Package | Was | Now |
|---|---|---|---|---|
| [GHSA-5p4m-2wfm-xmqj](https://github.com/advisories/GHSA-5p4m-2wfm-xmqj) | High | `js-yaml` (3.x) | 3.15.0 | 3.15.1 |
| [GHSA-5p4m-2wfm-xmqj](https://github.com/advisories/GHSA-5p4m-2wfm-xmqj) | High | `js-yaml` (4.x) | 4.3.0 | 4.3.1 |

## Why

Two new high-severity Dependabot alerts (#143, #144) opened against `main`: *"JS-YAML: Quadratic CPU consumption in `!!omap` resolution (3.x and 4.x) — CVE-2026-59870 fix not backported"*. The advisory affects `>= 3.0.0, < 3.15.1` and `>= 4.0.0, < 4.3.1`, so the versions this repo currently pins (3.15.0 and 4.3.0, set in #40) are both vulnerable.

This is a patch bump within each pinned major line, continuing the override pattern already used for these packages. Development scope only: `js-yaml` is reachable only through the `renovate` devDependency, which this repo uses solely to run `renovate-config-validator` in CI. Consumers that `extends` this preset are unaffected, since they consume `default.json` only.

## Verification

```
$ pnpm install --frozen-lockfile
Done in 3.7s using pnpm v11.1.2

$ renovate-config-validator default.json
 INFO: Validating default.json as global config
 INFO: Config validated successfully
```

Note: the `Renovate Config Validator` workflow only triggers on changes to `default.json`, which this PR does not touch, so it does not run here. The validator was run locally against the patched dependency tree instead.
