### PR TITLE
Remove obsolete pnpm 11.12.0 allowedVersions rule

### DIFF
--- a/default.json
+++ b/default.json
@@ -77,13 +77,6 @@
                 "!actions/{/,}**"
             ],
             "pinDigests": true
-        },
-        {
-            "description": "pnpm 11.12.0 is a broken release: its tarball fails to install, so any self-switch to it crashes (pnpm/pnpm#12955, pnpm/action-setup#276). Remove once a fixed release ships.",
-            "matchPackageNames": [
-                "pnpm"
-            ],
-            "allowedVersions": "!/^11\\.12\\.0$/"
         }
     ]
 }


### PR DESCRIPTION
## What

Remove the `packageRules` entry that excluded pnpm `11.12.0` via `allowedVersions: "!/^11\\.12\\.0$/"`. No other preset settings are changed.

## Why

The rule was a temporary workaround for a single broken pnpm release (see pnpm/pnpm#12955 and pnpm/action-setup#276). Every repository consuming this preset is already on a later pnpm release, and much newer versions (11.17+) have shipped since, so the exclusion can never match a version Renovate would propose today. Keeping it only adds noise to the shared preset.

Verified locally with `renovate-config-validator default.json` (config validated successfully).
